### PR TITLE
Handle library (or any files) named just they're *PREFIX for their type. Don't truncate them to blank string

### DIFF
--- a/SCons/Tool/linkCommon/SharedLibrary.py
+++ b/SCons/Tool/linkCommon/SharedLibrary.py
@@ -28,7 +28,7 @@ from . import lib_emitter, EmitLibSymlinks, StringizeLibSymlinks
 
 
 def shlib_symlink_emitter(target, source, env, **kw):
-    verbose = True
+    verbose = False
 
     if "variable_prefix" in kw:
         var_prefix = kw["variable_prefix"]
@@ -138,13 +138,15 @@ def _get_shlib_stem(target, source, env, for_signature: bool) -> str:
             % (target_name, shlibprefix, shlibsuffix)
         )
 
-    if shlibprefix and target_name.startswith(shlibprefix):
-        # skip pathlogical case were target _is_ the prefix
-        if target_name != shlibprefix:
-            target_name = target_name[len(shlibprefix) :]
 
     if shlibsuffix and target_name.endswith(shlibsuffix):
         target_name = target_name[: -len(shlibsuffix)]
+
+    if shlibprefix and target_name.startswith(shlibprefix):
+        # skip pathological case were target _is_ the prefix
+        if target_name != shlibprefix:
+            target_name = target_name[len(shlibprefix) :]
+
 
     if verbose and not for_signature:
         print("_get_shlib_stem: target_name:%s AFTER" % (target_name,))

--- a/SCons/Util.py
+++ b/SCons/Util.py
@@ -1115,7 +1115,7 @@ else:
 def adjustixes(fname, pre, suf, ensure_suffix=False):
     if pre:
         path, fn = os.path.split(os.path.normpath(fname))
-        if fn[:len(pre)] != pre:
+        if fn[:len(pre)] != pre or fn == pre:
             fname = os.path.join(path, pre + fn)
     # Only append a suffix if the suffix we're going to add isn't already
     # there, and if either we've been asked to ensure the specific suffix


### PR DESCRIPTION
Handle library (or any files) named just they're *PREFIX for their type. Don't truncate them to blank string