### PR TITLE
Fix test to work on windows where the default SHLIBPREFIX is empty string

### DIFF
--- a/SCons/Tool/linkCommon/linkCommmonTests.py
+++ b/SCons/Tool/linkCommon/linkCommmonTests.py
@@ -38,7 +38,7 @@ class SharedLibraryTestCase(unittest.TestCase):
         """Test shlib_symlink_emitter() """
         env = Environment(tools=['gnulink'])
 
-        target = env.SharedLibrary('lib', 'lib.c', SHLIBSUFFIX=".so")
+        target = env.SharedLibrary('lib', 'lib.c', SHLIBPREFIX='lib', SHLIBSUFFIX=".so")
 
         target_name = str(target[0])
         self.assertEqual(str(target_name), 'liblib.so', "Expected target 'liblib.so' != '%s'" % target_name)


### PR DESCRIPTION
Fix test to work on windows where the default SHLIBPREFIX is empty string