### PR TITLE
Change cache key to tuple and read/write list of dictionaries to json

### DIFF
--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -106,6 +106,9 @@ def read_script_env_cache():
         try:
             p = Path(CONFIG_CACHE)
             with p.open('r') as f:
+                # Convert the list of cache entry dictionaries read from
+                # json to the cache dictionary. Reconstruct the cache key
+                # tuple from the key list written to json.
                 envcache_list = json.load(f)
                 envcache = {tuple(d['key']): d['data'] for d in envcache_list}
         except FileNotFoundError:
@@ -120,6 +123,9 @@ def write_script_env_cache(cache):
         try:
             p = Path(CONFIG_CACHE)
             with p.open('w') as f:
+                # Convert the cache dictionary to a list of cache entry
+                # dictionaries. The cache key is converted from a tuple to
+                # a list for compatibility with json.
                 envcache_list = [{'key': list(key), 'data': data} for key, data in cache.items()]
                 json.dump(envcache_list, f, indent=2)
         except TypeError:

--- a/SCons/Tool/MSCommon/common.py
+++ b/SCons/Tool/MSCommon/common.py
@@ -106,7 +106,8 @@ def read_script_env_cache():
         try:
             p = Path(CONFIG_CACHE)
             with p.open('r') as f:
-                envcache = json.load(f)
+                envcache_list = json.load(f)
+                envcache = {tuple(d['key']): d['data'] for d in envcache_list}
         except FileNotFoundError:
             # don't fail if no cache file, just proceed without it
             pass
@@ -119,7 +120,8 @@ def write_script_env_cache(cache):
         try:
             p = Path(CONFIG_CACHE)
             with p.open('w') as f:
-                json.dump(cache, f, indent=2)
+                envcache_list = [{'key': list(key), 'data': data} for key, data in cache.items()]
+                json.dump(envcache_list, f, indent=2)
         except TypeError:
             # data can't serialize to json, don't leave partial file
             with suppress(FileNotFoundError):

--- a/SCons/Tool/MSCommon/vc.py
+++ b/SCons/Tool/MSCommon/vc.py
@@ -986,7 +986,7 @@ def script_env(script, args=None):
 
     if script_env_cache is None:
         script_env_cache = common.read_script_env_cache()
-    cache_key = f"{script}--{args}" if args else f"{script}"
+    cache_key = (script, args if args else None)
     cache_data = script_env_cache.get(cache_key, None)
 
     # Brief sanity check: if we got a value for the key,


### PR DESCRIPTION
Change msvc cache key from string to tuple.

Convert cache dictionary to a list of dictionaries with key tuple converted to key list when writing cache json file.
Convert list of dictionaries with key list converted to key tuple to the cache dictionary when reading cache json file.

## Contributor Checklist:

* [ ] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [ ] I have updated `CHANGES.txt` (and read the `README.rst`)
* [ ] I have updated the appropriate documentation
