### PR TITLE
rewording of CHANGES.txt info. Changed versionadded to 4.5.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -133,19 +133,14 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       Also added "unique" keyword, to control whether a library is added
       or not if it is already in the $LIBS construction var in the
       configure context. (issue #2768).
-    - Special-case handling for CPPDEFINES in the Append/Prepend routines
-      is split out into its own function to simplify the remaining code and
-      fix problems. The e2e test test/CPPDEFINES/append.py is expanded
-      to cover missed cases, and AppendUnique no longer mismatches
-      with what Append does (#3876).  Inconsistent handling of tuples
-      to specify macro=value outputs is also cleaned up (#4254). The
-      special handling now also works for Prepend/PrependUnique, and a
-      corresponding e2e test test/CPPDEFINES/prepend.py was added to verify
-      the behavior.  A unit test for SCons.Util.processDefines, used to
-      convert CPPDEFINES into a list of strings, is added.  SCons used
-      to sort keys set or appended via a dict type, in order to assure
-      order of commandline flags did not change across runs. This behavior
-      has been dropped since Python now assures consistent dict order.
+    - Completely refactored the CPPDEFINES logic in Append/AppendUnique/Prepend/PrependUnique
+      This change fixes the following GH Issues:
+      - GH Issue #3876 - Append() and AppendUnique() will handle CPPDEFINES the same
+      - GH Issue #4254 - Make handling tuples in CPPDEFINES consistent.
+      - We no longer sort the keys added to CPPDEFINES by their dictionary keys.
+        We take advantage that their order is now stable based on insertion order
+        in Python 3.5+
+      - Added/modifed unit and system tests to verify these changes.
 
 
 RELEASE 4.4.0 -  Sat, 30 Jul 2022 14:08:29 -0700

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -17,10 +17,10 @@ NOTE: If you build with Python 3.10.0 and then rebuild with 3.10.1 (or higher), 
       see unexpected rebuilds. This is due to Python internals changing which changed
       the signature of a Python Action Function.
 
-NOTE: If you use a dictionary to specify your CPPDEFINES, the order of
-      dictionary keys is now preserved when generating the command line.
-      Previously these were sorted alphabecially: this may cause a change
-      which leads to a rebuild.
+NOTE: If you use a dictionary to specify your CPPDEFINES, you may see unexpected build results
+      The insertion order of dictionary keys is now preserved when generating the command line.
+      Previously these were sorted alphabecially.  This change to the command line,
+      while generating identical set of CPPDEFINES can change order and cause a rebuild.
 
 
 NEW FUNCTIONALITY

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -17,7 +17,7 @@ NOTE: If you build with Python 3.10.0 and then rebuild with 3.10.1 (or higher), 
       see unexpected rebuilds. This is due to Python internals changing which changed
       the signature of a Python Action Function.
 
-NOTE: If you use a dictionary to specify your CPPDEFINES, you may see unexpected build results
+NOTE: If you use a dictionary to specify your CPPDEFINES, you may see an unexpected rebuild.
       The insertion order of dictionary keys is now preserved when generating the command line.
       Previously these were sorted alphabecially.  This change to the command line,
       while generating identical set of CPPDEFINES can change order and cause a rebuild.

--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -521,7 +521,7 @@ def processDefines(defs) -> List[str]:
 
     Any prefix/suffix is handled elsewhere (usually :func:`_concat_ixes`).
 
-    .. versionchanged:: 4.5
+    .. versionchanged:: 4.5.0
        Bare tuples are now treated the same as tuple-in-sequence, assumed
        to describe a valued macro. Bare strings are now split on space.
        A dictionary is no longer sorted before handling.

--- a/SCons/Environment.py
+++ b/SCons/Environment.py
@@ -223,7 +223,7 @@ def _add_cppdefines(
         unique: whether to add *val* if it already exists.
         delete_existing: if *unique* is true, add *val* after removing previous.
 
-    .. versionadded:: 4.5
+    .. versionadded:: 4.5.0
     """
 
     def _add_define(item, defines: deque, prepend: bool = False) -> None:


### PR DESCRIPTION
See description and:

There will be no version 4.5, these changes will be in version 4.5.0
(There may be a 4.5.1)
Also I think the CHANGES.txt changes are little easier to read and lead with the fact this is all about resolving outstanding issues with CPPDEFINES.

I think it's more useful to list the new test coverage, rather than the files they're changed/added in.
