### PR TITLE
Changed to YACC_GRAPH_FILE_SUFFIX. and some other changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,10 +23,12 @@ RELEASE  VERSION/DATE TO BE FILLED IN LATER
       calls dunder method __call__. Invoke instance directly."
     - Python 3.9 dropped the alias base64.decodestring, deprecated since 3.1.
       Only used in msvs.py. Use base64.decodebytes instead.
+    - Obsoleted YACCVCGFILESUFFIX, it's being replaced by YACC_GRAPH_FILE_SUFFIX.
+      If YACC_GRAPH_FILE_SUFFIX is not set, it will respect YACCVCGFILESUFFIX.
     - The yacc tool now understands the bison behavior of --header,
       --defines and --graph being called without option-argument as being
       synonyms for -d (first two) and -g. -H also recognized as a synonym
-      for -d.  Default value for $YACCVCGFILESUFFIX changed to '.gv'
+      for -d.  Default value for $YACC_GRAPH_FILE_SUFFIX changed to '.gv'
       to match current bison default (since bison 3.8).  The graph file name
       (-g) is now generated relative to the requested target file name,
       not to the source file name, to match actual current behavior (only

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -25,11 +25,12 @@ DEPRECATED FUNCTIONALITY
 
 CHANGED/ENHANCED EXISTING FUNCTIONALITY
 ---------------------------------------
-
+- Obsoleted YACCVCGFILESUFFIX, it's being replaced by YACC_GRAPH_FILE_SUFFIX.
+  If YACC_GRAPH_FILE_SUFFIX is not set, it will respect YACCVCGFILESUFFIX.
 - The yacc tool now understands the bison behavior of --header, --defines
   and --graph being called without an option-argument as being synonyms
   for -d (first two) and -g. -H also recognized as a synonym for -d.
-  Default value for $YACCVCGFILESUFFIX changed to '.gv' to match
+  Default value for $YACC_GRAPH_FILE_SUFFIX changed to '.gv' to match
   current bison default (since bison 3.8). Set this variable to '.dot'
   if using byacc.
 

--- a/SCons/Tool/yacc.py
+++ b/SCons/Tool/yacc.py
@@ -68,16 +68,18 @@ def _yaccEmitter(target, source, env, ysuf, hsuf) -> tuple:
 
     # If -d is specified on the command line, yacc will emit a .h
     # or .hpp file with the same base name as the .c or .cpp output file.
-    # if '-d' in flags:  # add bison options -H, --header, --defines (obsolete)
+    # if '-d' in flags: 
+    # or  bison options -H, --header, --defines (obsolete)
     if "-d" in flags or "-H" in flags or "--header" in flags or "--defines" in flags:
         target.append(targetBase + env.subst(hsuf, target=target, source=source))
 
     # If -g is specified on the command line, yacc will emit a graph
     # file with the same base name as the .c or .cpp output file.
     # TODO: should this be handled like -v? i.e. a side effect, not target
-    # if "-g" in flags:  # add bison option --graph
+    # if "-g" in flags:  
+    # or bison option --graph
     if "-g" in flags or "--graph" in flags:
-        target.append(targetBase + env.subst("$YACCVCGFILESUFFIX"))
+        target.append(targetBase + env.subst("$YACC_GRAPH_FILE_SUFFIX"))
 
     # If -v is specified yacc will create the output debug file
     # which is not really source for any process, but should
@@ -193,6 +195,7 @@ def generate(env) -> None:
     env['YACCHFILESUFFIX'] = '.h'
     env['YACCHXXFILESUFFIX'] = '.hpp'
     env['YACCVCGFILESUFFIX'] = '.gv'
+    env['YACC_GRAPH_FILE_SUFFIX'] = '$YACCVCGFILESUFFIX'
     env['_YACC_HEADER'] = '${YACC_HEADER_FILE and "--header=" + str(YACC_HEADER_FILE)}'
     env['_YACC_GRAPH'] = '${YACC_GRAPH_FILE and "--graph=" + str(YACC_GRAPH_FILE)}'
 

--- a/SCons/Tool/yacc.xml
+++ b/SCons/Tool/yacc.xml
@@ -58,6 +58,7 @@ Sets construction variables for the &yacc; parser generator.
 <item>YACCHFILESUFFIX</item>
 <item>YACCHXXFILESUFFIX</item>
 <item>YACCVCGFILESUFFIX</item>
+<item>YACC_GRAPH_FILE_SUFFIX</item>
 </sets>
 <uses>
 <item>YACCCOMSTR</item>
@@ -229,6 +230,20 @@ The default value is <filename>.hpp</filename>.
 
 <cvar name="YACCVCGFILESUFFIX">
 <summary>
+<para>
+Obsoleted. Use &cv-link-ACC_GRAPH_FILE_SUFFIX;.
+</para>
+<para>
+<emphasis>Changed in version 4.X.Y</emphasis>
+</para>
+</summary>
+</cvar>
+
+<cvar name="YACC_GRAPH_FILE_SUFFIX">
+<summary>
+<para>
+Previously specified by &cv-link-YACCVCGFILESUFFIX;.
+</para>
 <para>
 The suffix of the file
 containing a graph of the grammar automaton

--- a/test/YACC/YACC_GRAPH_FILE_SUFFIX.py
+++ b/test/YACC/YACC_GRAPH_FILE_SUFFIX.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# Copyright The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+Test setting the YACC_GRAPH_FILE_SUFFIX variable.
+Also that if both YACCVCGFILESUFFIX and YACC_GRAPH_FILE_SUFFIX are set,
+then YACCVCGFILESUFFIX will be ignored.
+"""
+
+import TestSCons
+
+_python_ = TestSCons._python_
+
+test = TestSCons.TestSCons()
+
+test.write('myyacc.py', """\
+import getopt
+import os.path
+import sys
+
+vcg = None
+opts, args = getopt.getopt(sys.argv[1:], 'go:')
+for o, a in opts:
+    if o == '-g':
+        vcg = 1
+    elif o == '-o':
+        outfile = open(a, 'wb')
+for f in args:
+    with open(f, 'rb') as infile:
+        for l in [l for l in infile.readlines() if l != b'/*yacc*/\\n']:
+            outfile.write(l)
+outfile.close()
+if vcg:
+    base, ext = os.path.splitext(args[0])
+    with open(base + '.graph_suffix', 'wb') as outfile:
+        outfile.write((" ".join(sys.argv) + '\\n').encode())
+sys.exit(0)
+""")
+
+test.write('SConstruct', """
+DefaultEnvironment(tools=[])
+env = Environment(
+    tools=['default', 'yacc'],
+    YACC=r'%(_python_)s myyacc.py',
+    YACCVCGFILESUFFIX='.vcg_obsolete',
+    YACC_GRAPH_FILE_SUFFIX='.graph_suffix',
+)
+env.CXXFile(target='aaa', source='aaa.yy')
+env.CXXFile(target='bbb', source='bbb.yy', YACCFLAGS='-g')
+""" % locals())
+
+test.write('aaa.yy', "aaa.yy\n/*yacc*/\n")
+test.write('bbb.yy', "bbb.yy\n/*yacc*/\n")
+
+test.run(arguments='.')
+
+test.must_match('aaa.cc', "aaa.yy\n")
+test.must_not_exist('aaa.vcg')
+test.must_not_exist('aaa.graph_suffix')
+
+test.must_match('bbb.cc', "bbb.yy\n")
+test.must_not_exist('bbb.vcg')
+test.must_not_exist('bbb.vcg_obsolete')
+test.must_contain('bbb.graph_suffix', "myyacc.py -g -o bbb.cc bbb.yy\n")
+
+test.up_to_date(arguments='.')
+
+test.pass_test()
+
+# Local Variables:
+# tab-width:4
+# indent-tabs-mode:nil
+# End:
+# vim: set expandtab tabstop=4 shiftwidth=4:


### PR DESCRIPTION
Changed to YACC_GRAPH_FILE_SUFFIX.
It will use YACCVCGFILESUFFIX's value if not set. 


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
