### PR TITLE
Remove implicit usage of LIBLITERAL in _stripixes()

### DIFF
--- a/SCons/Defaults.py
+++ b/SCons/Defaults.py
@@ -462,6 +462,7 @@ def _stripixes(
     stripprefixes: str,
     stripsuffixes: str,
     env,
+    literal_prefix: str = "",
     c: Callable[[list], list] = None,
 ) -> list:
     """Returns a list with text added to items after first stripping them.
@@ -498,14 +499,13 @@ def _stripixes(
     stripprefixes = list(map(env.subst, flatten(stripprefixes)))
     stripsuffixes = list(map(env.subst, flatten(stripsuffixes)))
 
-    # This is a little funky: if $LIBLITERAL is the same as os.pathsep
+    # This is a little funky: if literal_prefix is the same as os.pathsep
     # (e.g. both ':'), the normal conversion to a PathList will drop the
-    # $LIBLITERAL prefix. Tell it not to split in that case, which *should*
+    # literal_prefix prefix. Tell it not to split in that case, which *should*
     # be okay because if we come through here, we're normally processing
     # library names and won't have strings like "path:secondpath:thirdpath"
     # which is why PathList() otherwise wants to split strings.
-    libliteral = env.get('LIBLITERAL')
-    do_split = not libliteral == os.pathsep
+    do_split = not literal_prefix == os.pathsep
 
     stripped = []
     for l in SCons.PathList.PathList(items, do_split).subst_path(env, None, None):
@@ -516,7 +516,7 @@ def _stripixes(
         if not is_String(l):
             l = str(l)
 
-        if libliteral and l.startswith(libliteral):
+        if literal_prefix and l.startswith(literal_prefix):
             stripped.append(l)
             continue
 

--- a/SCons/EnvironmentTests.py
+++ b/SCons/EnvironmentTests.py
@@ -1538,8 +1538,19 @@ def exists(env):
             LIBSUFFIXES=['.yyy'],
             LIBLITERAL='zz',
         )
-        x = e.subst('$( ${_stripixes(PRE, LIST, SUF, LIBPREFIXES, LIBSUFFIXES,__env__)} $)')
+        x = e.subst('$( ${_stripixes(PRE, LIST, SUF, LIBPREFIXES, LIBSUFFIXES,__env__, LIBLITERAL)} $)')
         self.assertEqual(x, 'preasuf prebsuf prezzxxx-c.yyysuf')
+
+        # Test that setting literal_prefix (in this case LIBLITERAL)
+        # same as os.pathsep disables the literal protection
+        e['LIBLITERAL'] = os.pathsep
+        x = e.subst('$( ${_stripixes(PRE, LIST, SUF, LIBPREFIXES, LIBSUFFIXES,__env__, LIBLITERAL)} $)')
+        self.assertEqual(x, 'preasuf prebsuf prezzxxx-csuf')
+
+        # Test that setting not settingliteral_prefix doesn't fail
+        x = e.subst('$( ${_stripixes(PRE, LIST, SUF, LIBPREFIXES, LIBSUFFIXES,__env__)} $)')
+        self.assertEqual(x, 'preasuf prebsuf prezzxxx-csuf')
+
 
 
     def test_gvars(self) -> None:

--- a/SCons/Tool/dmd.py
+++ b/SCons/Tool/dmd.py
@@ -138,7 +138,7 @@ def generate(env) -> None:
 
     env['DLIBLINKPREFIX'] = '' if env['PLATFORM'] == 'win32' else '-L-l'
     env['DLIBLINKSUFFIX'] = '.lib' if env['PLATFORM'] == 'win32' else ''
-    env['_DLIBFLAGS'] = '${_stripixes(DLIBLINKPREFIX, LIBS, DLIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES,  __env__)}'
+    env['_DLIBFLAGS'] = '${_stripixes(DLIBLINKPREFIX, LIBS, DLIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES,  __env__, LIBLITERAL)}'
 
     env['DLIBDIRPREFIX'] = '-L-L'
     env['DLIBDIRSUFFIX'] = ''

--- a/SCons/Tool/ldc.py
+++ b/SCons/Tool/ldc.py
@@ -73,7 +73,7 @@ def generate(env) -> None:
     env['_DDEBUGFLAGS'] = '${_concat(DDEBUGPREFIX, DDEBUG, DDEBUGSUFFIX, __env__)}'
 
     env['_DI_FLAGS'] = "${DI_FILE_DIR and DI_FILE_DIR_PREFIX+DI_FILE_DIR+DI_FILE_DIR_SUFFFIX}"
-    
+
     env['_DFLAGS'] = '${_concat(DFLAGPREFIX, DFLAGS, DFLAGSUFFIX, __env__)}'
 
     env['SHDC'] = '$DC'
@@ -96,10 +96,10 @@ def generate(env) -> None:
     env['DFLAGPREFIX'] = '-'
     env['DFLAGSUFFIX'] = ''
     env['DFILESUFFIX'] = '.d'
-    
+
     env['DI_FILE_DIR'] = ''
     env['DI_FILE_SUFFIX'] = '.di'
-    
+
     env['DI_FILE_DIR_PREFIX'] = '-Hd='
     env['DI_FILE_DIR_SUFFFIX'] = ''
 
@@ -115,7 +115,7 @@ def generate(env) -> None:
     env['DLIBLINKPREFIX'] = '' if env['PLATFORM'] == 'win32' else '-L-l'
     env['DLIBLINKSUFFIX'] = '.lib' if env['PLATFORM'] == 'win32' else ''
     # env['_DLIBFLAGS'] = '${_concat(DLIBLINKPREFIX, LIBS, DLIBLINKSUFFIX, __env__, RDirs, TARGET, SOURCE)}'
-    env['_DLIBFLAGS'] = '${_stripixes(DLIBLINKPREFIX, LIBS, DLIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES,  __env__)}'
+    env['_DLIBFLAGS'] = '${_stripixes(DLIBLINKPREFIX, LIBS, DLIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES,  __env__, LIBLITERAL)}'
 
     env['DLIBDIRPREFIX'] = '-L-L'
     env['DLIBDIRSUFFIX'] = ''

--- a/SCons/Tool/link.py
+++ b/SCons/Tool/link.py
@@ -55,7 +55,7 @@ def generate(env) -> None:
     env['LINKCOM'] = '$LINK -o $TARGET $LINKFLAGS $__RPATH $SOURCES $_LIBDIRFLAGS $_LIBFLAGS'
     env['LIBDIRPREFIX'] = '-L'
     env['LIBDIRSUFFIX'] = ''
-    env['_LIBFLAGS'] = '${_stripixes(LIBLINKPREFIX, LIBS, LIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES, __env__)}'
+    env['_LIBFLAGS'] = '${_stripixes(LIBLINKPREFIX, LIBS, LIBLINKSUFFIX, LIBPREFIXES, LIBSUFFIXES, __env__, LIBLITERAL)}'
     env['LIBLINKPREFIX'] = '-l'
     env['LIBLINKSUFFIX'] = ''
 


### PR DESCRIPTION
Switch from embedding LIBLITERAL in _stripixes() to being a passed argument with a False default value, and add properly passing LI
BLITERAL in link, dmd, ldc tools where _stripixes() is actually used in current SCons Code


## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `CHANGES.txt` (and read the `README.rst`)
* [x] I have updated the appropriate documentation
