### PR TITLE
Fixed to work with variant, Dir(),etc 

### DIFF
--- a/SCons/Scanner/Fortran.py
+++ b/SCons/Scanner/Fortran.py
@@ -31,6 +31,7 @@ import SCons.Warnings
 from SCons.Util import unique
 from . import Classic, Current, FindPathDirs
 
+
 class F90Scanner(Classic):
     """A Classic Scanner subclass for Fortran source files.
 
@@ -139,9 +140,14 @@ class F90Scanner(Classic):
             path = path()
         for include in includes:
             _add_dep(include, source_dir, tuple(path))
+
         # Have to mimic compiler behavior of also looking in module dir.
-        mod_dir = env.subst('$FORTRANMODDIR') if modules else ""
-        mod_path = (env.fs.Dir(mod_dir),) if mod_dir else ()
+        if env.get('FORTRANMODDIR') and env.subst('$FORTRANMODDIR'):
+            # Add this path to the list of paths searched for used modules
+            mod_path = (env.Dir('$FORTRANMODDIR'),)
+        else:
+            mod_path = ()
+
         for module in modules:
             _add_dep(module, source_dir, path + mod_path)
 

--- a/SCons/Tool/gfortran.py
+++ b/SCons/Tool/gfortran.py
@@ -32,7 +32,7 @@ selection method.
 from SCons.Util import CLVar
 from SCons.Tool.FortranCommon import add_all_to_env, add_fortran_to_env
 
-compilers = ['gfortran']
+compilers = ['gfortran', 'gfortran-mp-13']
 
 
 def generate(env) -> None:

--- a/test/Fortran/F08.py
+++ b/test/Fortran/F08.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Fortran/F08FILESUFFIXES2.py
+++ b/test/Fortran/F08FILESUFFIXES2.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 import TestSCons
 

--- a/test/Fortran/fixture/myfortran.py
+++ b/test/Fortran/fixture/myfortran.py
@@ -8,7 +8,7 @@ import sys
 print(sys.argv)
 comment = ('#' + sys.argv[1]).encode()
 
-opts, args = getopt.getopt(sys.argv[2:], 'cf:o:K:')
+opts, args = getopt.getopt(sys.argv[2:], 'cf:J:o:K:')
 for opt, arg in opts:
     if opt == '-o':
         out = arg

--- a/test/Fortran/fixture/myfortran_flags.py
+++ b/test/Fortran/fixture/myfortran_flags.py
@@ -7,7 +7,7 @@ import sys
 
 comment = ('#' + sys.argv[1]).encode()
 
-opts, args = getopt.getopt(sys.argv[2:], 'cf:o:xyz')
+opts, args = getopt.getopt(sys.argv[2:], 'cf:J:o:xyz')
 optstring = ''
 length = len(comment)
 for opt, arg in opts:

--- a/test/Fortran/gfortran.py
+++ b/test/Fortran/gfortran.py
@@ -35,10 +35,19 @@ test = TestSCons.TestSCons()
 
 _exe = TestSCons._exe
 
-gfortran = test.detect_tool('gfortran')
+from SCons.Tool.gfortran import compilers
 
-if not gfortran:
-    test.skip_test("Could not find gfortran tool, skipping test.\n")
+# Handle multiple possible gfortran binary names
+found = False
+for c in compilers:
+    if test.where_is(c):
+        found = True
+        break
+
+if not found:
+    compiler_list = " or ".join(compilers)
+    test.skip_test(f"Could not find {compiler_list}, skipping test.\n")
+
 
 test.write('SConstruct', """
 env = Environment(tools=['gfortran','link'])
@@ -61,7 +70,7 @@ program main
 end program main
 """)
 
-test.run(arguments = '.')
+test.run(arguments='.')
 
 test.must_exist('test1' + _exe)
 test.must_exist('test1mod.mod')

--- a/test/Fortran/module-subdir.py
+++ b/test/Fortran/module-subdir.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 #
-# __COPYRIGHT__
+# MIT License
+#
+# Copyright The SCons Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -20,9 +22,6 @@
 # LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-#
-
-__revision__ = "__FILE__ __REVISION__ __DATE__ __DEVELOPER__"
 
 """
 Validate that $FORTRANMODDIR values get expanded correctly on Fortran
@@ -87,7 +86,7 @@ env.Library('bidule', objs)
 test.write(['subdir', 'SConscript'], """\
 Import('env')
 
-env['FORTRANMODDIR'] = 'build'
+env['FORTRANMODDIR'] = Dir('build')
 sources = ['src/modfile.f']
 objs = env.Object(sources)
 Return("objs")


### PR DESCRIPTION
Updates to get FORTRANMODDIR to work with and without variant dirs, with and without duplicate, set as string or as Dir()

Of note:
if plain string and not #/path , it'll now always be relative to #

